### PR TITLE
Add keyboard navigation to search results and fix bbox bounds

### DIFF
--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -7,11 +7,13 @@ export default function SearchBox({ onPick }: Props) {
   const [q, setQ] = useState("");
   const [open, setOpen] = useState(false);
   const [results, setResults] = useState<Result[]>([]);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!q) {
       setResults([]);
+      setActiveIndex(null);
       return;
     }
     if (timer.current) clearTimeout(timer.current);
@@ -22,8 +24,10 @@ export default function SearchBox({ onPick }: Props) {
         const data: Result[] = await res.json();
         setResults(data);
         setOpen(true);
+        setActiveIndex(null);
       } catch {
         setResults([]);
+        setActiveIndex(null);
       }
     }, 250);
     return () => {
@@ -39,18 +43,56 @@ export default function SearchBox({ onPick }: Props) {
         placeholder="Search a city or neighbourhood"
         className="w-full rounded-xl border px-4 py-2 shadow-sm"
         onFocus={() => q && setOpen(true)}
-        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        onBlur={() =>
+          setTimeout(() => {
+            setOpen(false);
+            setActiveIndex(null);
+          }, 150)
+        }
         aria-label="Search places"
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setOpen(true);
+            setActiveIndex((i) => {
+              const n = results.length;
+              if (!n) return null;
+              return i === null ? 0 : Math.min(i + 1, n - 1);
+            });
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setActiveIndex((i) => {
+              const n = results.length;
+              if (!n) return null;
+              return i === null ? n - 1 : Math.max(i - 1, 0);
+            });
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            const pick = activeIndex !== null ? results[activeIndex] : results[0];
+            if (pick) {
+              setQ(pick.name);
+              setOpen(false);
+              setActiveIndex(null);
+              onPick(pick);
+            }
+          } else if (e.key === "Escape") {
+            setOpen(false);
+            setActiveIndex(null);
+          }
+        }}
       />
       {open && results.length > 0 && (
         <ul className="absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-xl border bg-white shadow">
           {results.map((r, i) => (
             <li
               key={`${r.lat}-${r.lon}-${i}`}
-              className="cursor-pointer px-3 py-2 hover:bg-gray-100"
+              className={`cursor-pointer px-3 py-2 ${
+                activeIndex === i ? "bg-gray-100" : "hover:bg-gray-100"
+              }`}
               onMouseDown={() => {
                 setOpen(false);
                 setQ(r.name);
+                setActiveIndex(null);
                 onPick(r);
               }}
             >

--- a/components/map-container.tsx
+++ b/components/map-container.tsx
@@ -399,10 +399,13 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(({ onMapStat
     if (!mapRef.current || !window.L) return
     try {
       if (result.bbox && result.bbox.length === 4) {
-        const bounds = window.L.latLngBounds(
-          [result.bbox[1], result.bbox[0]],
-          [result.bbox[3], result.bbox[2]],
-        )
+        const south = result.bbox[0]
+        const north = result.bbox[1]
+        const west = result.bbox[2]
+        const east = result.bbox[3]
+        const sw = [south, west] as [number, number]
+        const ne = [north, east] as [number, number]
+        const bounds = window.L.latLngBounds(sw, ne)
         if (bounds.isValid()) {
           mapRef.current.fitBounds(bounds, { padding: [48, 48], maxZoom: 16 })
           return


### PR DESCRIPTION
## Summary
- add keyboard navigation for the search box so arrow keys move an active highlight, Enter selects the current result, and Escape closes the menu
- ensure map fly-to uses the correct bounding box order when fitting Leaflet bounds from geocoder responses

## Testing
- pnpm lint *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cc83f0e268832aafb0f6bfd15bee2e