### PR TITLE
Integrate place search with map navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import { useRef, useState, useEffect } from "react"
+import type { ForwardRefExoticComponent, RefAttributes } from "react"
 import dynamic from "next/dynamic"
 import { MobileHeader } from "@/components/mobile-header"
 import { ToastNotification } from "@/components/toast-notification"
 import { ShareButton } from "@/components/share-button"
 import { useUrlState } from "@/hooks/use-url-state"
+import type { MapContainerProps, MapContainerRef } from "@/components/map-container"
+import type { PlaceResult } from "@/components/SearchBox"
 
 // Dynamically import map components to avoid SSR issues
 const MapContainer = dynamic(() => import("@/components/map-container"), {
@@ -15,13 +18,13 @@ const MapContainer = dynamic(() => import("@/components/map-container"), {
       <div className="text-muted-foreground">Loading map...</div>
     </div>
   ),
-})
+}) as ForwardRefExoticComponent<MapContainerProps & RefAttributes<MapContainerRef>>
 
 export default function SurveyMapPage() {
   const [isSearching, setIsSearching] = useState(false)
   const [searchError, setSearchError] = useState<string | null>(null)
   const [currentMapState, setCurrentMapState] = useState({ zoom: 4, lat: 39.8283, lng: -98.5795 })
-  const mapRef = useRef<any>(null)
+  const mapRef = useRef<MapContainerRef | null>(null)
   const { parseUrlState, updateUrlState, getShareableUrl, clearUrlState } = useUrlState()
 
   useEffect(() => {
@@ -133,6 +136,10 @@ export default function SurveyMapPage() {
     return mapRef.current?.getSuggestions?.(query) || []
   }
 
+  const handleNavigateToPlace = (result: PlaceResult) => {
+    mapRef.current?.navigateToPlace(result)
+  }
+
   return (
     <div className="relative w-full h-screen overflow-hidden bg-background">
       {/* Responsive Header */}
@@ -141,6 +148,8 @@ export default function SurveyMapPage() {
         getSuggestions={getSuggestions}
         isSearching={isSearching}
         onClearSearch={handleClearSearch}
+        onGetShareUrl={getShareUrl}
+        onNavigateToPlace={handleNavigateToPlace}
       />
 
       {/* Share Button - Desktop */}

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 
-type Result = { name: string; lat: number; lon: number; bbox?: [number, number, number, number] };
-type Props = { onPick: (r: Result) => void };
+import { cn } from "@/lib/utils";
 
-export default function SearchBox({ onPick }: Props) {
+export type PlaceResult = { name: string; lat: number; lon: number; bbox?: [number, number, number, number] };
+type Props = { onPick: (r: PlaceResult) => void; className?: string };
+
+export default function SearchBox({ onPick, className }: Props) {
   const [q, setQ] = useState("");
   const [open, setOpen] = useState(false);
-  const [results, setResults] = useState<Result[]>([]);
+  const [results, setResults] = useState<PlaceResult[]>([]);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -21,7 +23,7 @@ export default function SearchBox({ onPick }: Props) {
       try {
         const res = await fetch(`/api/geocode?q=${encodeURIComponent(q)}`);
         if (!res.ok) return;
-        const data: Result[] = await res.json();
+        const data: PlaceResult[] = await res.json();
         setResults(data);
         setOpen(true);
         setActiveIndex(null);
@@ -36,12 +38,12 @@ export default function SearchBox({ onPick }: Props) {
   }, [q]);
 
   return (
-    <div className="relative w-full max-w-md">
+    <div className={cn("relative w-64", className)}>
       <input
         value={q}
         onChange={(e) => setQ(e.target.value)}
         placeholder="Search a city or neighbourhood"
-        className="w-full rounded-xl border px-4 py-2 shadow-sm"
+        className="w-full h-9 rounded-lg border border-border bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
         onFocus={() => q && setOpen(true)}
         onBlur={() =>
           setTimeout(() => {
@@ -82,13 +84,16 @@ export default function SearchBox({ onPick }: Props) {
         }}
       />
       {open && results.length > 0 && (
-        <ul className="absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-xl border bg-white shadow">
+        <ul className="absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-xl border bg-popover text-popover-foreground shadow">
           {results.map((r, i) => (
             <li
               key={`${r.lat}-${r.lon}-${i}`}
-              className={`cursor-pointer px-3 py-2 ${
-                activeIndex === i ? "bg-gray-100" : "hover:bg-gray-100"
-              }`}
+              className={cn(
+                "cursor-pointer px-3 py-2 text-sm",
+                activeIndex === i
+                  ? "bg-accent text-accent-foreground"
+                  : "hover:bg-accent hover:text-accent-foreground",
+              )}
               onMouseDown={() => {
                 setOpen(false);
                 setQ(r.name);

--- a/components/map-container.tsx
+++ b/components/map-container.tsx
@@ -5,7 +5,6 @@ import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Layers } from "lucide-react"
 import { MapStats } from "./map-stats"
-import SearchBox from "./SearchBox"
 import { ToastNotification } from "./toast-notification"
 
 declare global {
@@ -24,7 +23,7 @@ interface SurveyPoint {
 
 const sanitizeCssClass = (str: string): string => str.replace(/[^a-zA-Z0-9_-]/g, "_")
 
-type MapContainerProps = {
+export type MapContainerProps = {
   onMapStateChange?: (state: { zoom: number; lat: number; lng: number }) => void
   initialState?: { zoom: number; lat: number; lng: number }
 }
@@ -32,6 +31,7 @@ type MapContainerProps = {
 export interface MapContainerRef {
   searchAndFlyTo: (cellId: string) => Promise<boolean>
   getSuggestions: (query: string) => string[]
+  navigateToPlace: (result: { lat: number; lon: number; bbox?: [number, number, number, number] }) => void
 }
 
 /** helpers to load external assets once */
@@ -128,6 +128,31 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(({ onMapStat
     }
   }
 
+  const navigateToPlace = (result: { lat: number; lon: number; bbox?: [number, number, number, number] }) => {
+    if (!mapRef.current || !window.L) return
+    try {
+      if (result.bbox && result.bbox.length === 4) {
+        const south = result.bbox[0]
+        const north = result.bbox[1]
+        const west = result.bbox[2]
+        const east = result.bbox[3]
+        const sw = [south, west] as [number, number]
+        const ne = [north, east] as [number, number]
+        const bounds = window.L.latLngBounds(sw, ne)
+        if (bounds.isValid()) {
+          mapRef.current.fitBounds(bounds, { padding: [48, 48], maxZoom: 16 })
+          return
+        }
+      }
+
+      const current = typeof mapRef.current.getZoom === "function" ? mapRef.current.getZoom() : 0
+      const targetZoom = current && current > 0 ? Math.max(current, 14) : 14
+      mapRef.current.flyTo([result.lat, result.lon], targetZoom, { duration: 1.2 })
+    } catch (e) {
+      console.warn("[v0] Search navigation error", e)
+    }
+  }
+
   useImperativeHandle(ref, () => ({
     searchAndFlyTo: async (cellId: string): Promise<boolean> => {
       const point = surveyPoints.find((p) => p.cell_id.toLowerCase() === cellId.toLowerCase())
@@ -174,6 +199,7 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(({ onMapStat
         .map((p) => p.cell_id)
         .sort()
     },
+    navigateToPlace,
   }))
 
   const loadGeoJSONData = async (): Promise<SurveyPoint[]> => {
@@ -395,31 +421,6 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(({ onMapStat
     setCurrentBasemap(newBasemap)
   }
 
-  const flyToResult = (result: { lat: number; lon: number; bbox?: [number, number, number, number] }) => {
-    if (!mapRef.current || !window.L) return
-    try {
-      if (result.bbox && result.bbox.length === 4) {
-        const south = result.bbox[0]
-        const north = result.bbox[1]
-        const west = result.bbox[2]
-        const east = result.bbox[3]
-        const sw = [south, west] as [number, number]
-        const ne = [north, east] as [number, number]
-        const bounds = window.L.latLngBounds(sw, ne)
-        if (bounds.isValid()) {
-          mapRef.current.fitBounds(bounds, { padding: [48, 48], maxZoom: 16 })
-          return
-        }
-      }
-
-      const current = typeof mapRef.current.getZoom === "function" ? mapRef.current.getZoom() : 0
-      const targetZoom = current && current > 0 ? Math.max(current, 14) : 14
-      mapRef.current.flyTo([result.lat, result.lon], targetZoom, { duration: 1.2 })
-    } catch (e) {
-      console.warn("[v0] Search navigation error", e)
-    }
-  }
-
   if (!leafletLoaded) {
     return (
       <div className="w-full h-full flex items-center justify-center bg-muted">
@@ -434,12 +435,8 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(({ onMapStat
   }
 
   return (
-  <div className="relative w-full h-full">
-    <div ref={mapContainerRef} className="w-full h-full" />
-
-    <div className="absolute left-4 top-4 z-[2000] pointer-events-auto">
-      <SearchBox onPick={flyToResult} />
-    </div>
+    <div className="relative w-full h-full">
+      <div ref={mapContainerRef} className="w-full h-full" />
 
       {isLoading && (
         <div className="absolute inset-0 bg-background/50 flex items-center justify-center z-[1000]">

--- a/components/mobile-header.tsx
+++ b/components/mobile-header.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Map, Menu, X } from "lucide-react"
-import { SearchBox } from "./search-box"
+import PlaceSearchBox, { PlaceResult } from "./SearchBox"
+import { SearchBox as CellSearchBox } from "./search-box"
 import { ShareButton } from "./share-button"
 
 interface MobileHeaderProps {
@@ -12,6 +13,7 @@ interface MobileHeaderProps {
   isSearching: boolean
   onClearSearch?: () => void
   onGetShareUrl?: () => string
+  onNavigateToPlace?: (result: PlaceResult) => void
 }
 
 export function MobileHeader({
@@ -20,13 +22,14 @@ export function MobileHeader({
   isSearching,
   onClearSearch,
   onGetShareUrl,
+  onNavigateToPlace,
 }: MobileHeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
     <>
       {/* Mobile Header */}
-      <header className="md:hidden absolute top-0 left-0 right-0 z-[1000] bg-background/95 backdrop-blur-md border-b border-border">
+      <header className="md:hidden absolute top-0 left-0 right-0 z-[2000] bg-background/95 backdrop-blur-md border-b border-border">
         <div className="flex items-center justify-between px-4 py-3">
           <div className="flex items-center gap-2">
             <Map className="w-5 h-5 text-primary" />
@@ -46,31 +49,37 @@ export function MobileHeader({
         {/* Mobile Search Panel */}
         {isMenuOpen && (
           <div className="border-t border-border bg-background/95 backdrop-blur-md p-4 animate-in slide-in-from-top-2 duration-200">
-            <SearchBox
-              onSearch={onSearch}
-              getSuggestions={getSuggestions}
-              isSearching={isSearching}
-              onClear={onClearSearch}
-              className="w-full"
-            />
+            <div className="flex flex-col gap-3">
+              {onNavigateToPlace && <PlaceSearchBox onPick={onNavigateToPlace} className="w-full" />}
+              <CellSearchBox
+                onSearch={onSearch}
+                getSuggestions={getSuggestions}
+                isSearching={isSearching}
+                onClear={onClearSearch}
+                className="w-full"
+              />
+            </div>
           </div>
         )}
       </header>
 
       {/* Desktop Header */}
-      <header className="hidden md:flex absolute top-0 left-0 right-0 z-[1000] bg-background/80 backdrop-blur-md border-b border-border">
+      <header className="hidden md:flex absolute top-0 left-0 right-0 z-[2000] bg-background/80 backdrop-blur-md border-b border-border">
         <div className="flex items-center justify-between px-4 py-3 w-full">
           <div className="flex items-center gap-2">
             <Map className="w-5 h-5 text-primary" />
             <h1 className="text-lg font-semibold text-foreground">Survey Map</h1>
           </div>
 
-          <SearchBox
-            onSearch={onSearch}
-            getSuggestions={getSuggestions}
-            isSearching={isSearching}
-            onClear={onClearSearch}
-          />
+          <div className="flex items-center gap-3">
+            {onNavigateToPlace && <PlaceSearchBox onPick={onNavigateToPlace} />}
+            <CellSearchBox
+              onSearch={onSearch}
+              getSuggestions={getSuggestions}
+              isSearching={isSearching}
+              onClear={onClearSearch}
+            />
+          </div>
         </div>
       </header>
     </>


### PR DESCRIPTION
## Summary
- expose a `navigateToPlace` ref method in the map container and remove the embedded place search overlay
- restyle the shared SearchBox component and export its result type for reuse
- render the place search box from the header on desktop and mobile, wiring it to the map ref and typing the map container usage

## Testing
- pnpm lint *(fails: prompts for initial ESLint configuration)*
- pnpm build *(fails: Next.js cannot download Inter font in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc89f8a1a8832a898937aab224f55b